### PR TITLE
- In `ProductDetailsViewModel`, modified `getDraftOrder` to accept `c…

### DIFF
--- a/app/src/main/java/com/example/m_commerce/presentation/authentication/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/m_commerce/presentation/authentication/login/LoginViewModel.kt
@@ -50,22 +50,22 @@ class LoginViewModel  @Inject constructor(
                         if (user?.isEmailVerified == true) {
                             fetchShopifyCustomerId(email)
                             _loginState.value = ResponseState.Success("Welcome back! You have successfully logged in")
-                            val customerId = sharedPreferencesHelper.getCustomerId()
-//                            viewModelScope.launch {
-//                                customerId?.let {
-//                                    try {
-//                                        getDraftOrder(it).let { hasExistingOrder ->
-//                                            if (hasExistingOrder) {
-//                                                Log.d("LoginViewModel", "Draft order already exists for customer: $customerId")
-//                                            } else {
-//                                                Log.d("LoginViewModel", "No existing draft order found for customer: $customerId")
-//                                            }
-//                                        }
-//                                    } catch (e: Exception) {
-//                                        Log.e("LoginViewModel", "Error checking draft order", e)
-//                                    }
-//                                }
-//                            }
+                            val customerEmail = sharedPreferencesHelper.getCustomerEmail()
+                            viewModelScope.launch {
+                                customerEmail?.let {
+                                    try {
+                                        getDraftOrder(it).let { hasExistingOrder ->
+                                            if (hasExistingOrder) {
+                                                Log.d("LoginViewModel", "Draft order already exists for customer: $customerEmail")
+                                            } else {
+                                                Log.d("LoginViewModel", "No existing draft order found for customer: $customerEmail")
+                                            }
+                                        }
+                                    } catch (e: Exception) {
+                                        Log.e("LoginViewModel", "Error checking draft order", e)
+                                    }
+                                }
+                            }
                         } else {
                             auth.signOut()
                             _loginState.value = ResponseState.Failure(

--- a/app/src/main/java/com/example/m_commerce/presentation/cart/CartViewModel.kt
+++ b/app/src/main/java/com/example/m_commerce/presentation/cart/CartViewModel.kt
@@ -60,6 +60,7 @@ class CartViewModel @Inject constructor(
                 if (draftOrders.note2 == noteType.name) {
                     currentOrder = draftOrders
                     _cartState.value = ResponseState.Success(draftOrders)
+                    sharedPreferencesHelper.saveCartDraftOrderId(draftOrders.id.toString())
                     Log.d("CartViewModel", "Found cart: ${draftOrders.note2}")
                     Log.d("CartViewModel", "Found cart: ${draftOrders}")
                 }

--- a/app/src/main/java/com/example/m_commerce/presentation/productDetails/ProductDetailsViewModel.kt
+++ b/app/src/main/java/com/example/m_commerce/presentation/productDetails/ProductDetailsViewModel.kt
@@ -90,13 +90,12 @@ class ProductDetailsViewModel @Inject constructor(
                 val draftOrderId = sharedPreferencesHelper.getCartDraftOrderId()
 
                 try {
-                    val (hasExistingOrder, currentLineItems) = getDraftOrder(draftOrderId.toString(), note.cart)
+                    val (hasExistingOrder, currentLineItems) = getDraftOrder(customerEmail.toString(), note.cart)
                     Log.d("ProductDetailsViewModel", "Draft order check complete: hasExistingOrder=$hasExistingOrder, currentLineItems=$currentLineItems")
                     if (hasExistingOrder) {
                         updateExistingCart(variantId, currentLineItems, quantity)
                         Log.d("ProductDetailsViewModel", "Existing cart updated")
                     } else {
-                        // Create new cart if getDraftOrder returns no data
                         createNewCart(variantId, customerEmail, quantity)
                         Log.d("ProductDetailsViewModel", "New cart created")
                     }


### PR DESCRIPTION
…ustomerEmail` instead of `draftOrderId`. Removed the fallback to creating a new cart if `getDraftOrder` returns no data.

- In `LoginViewModel`, updated logic to check for existing draft orders using `customerEmail` after successful login.
- In `CartViewModel`, added functionality to save the `draftOrderId` to `SharedPreferences` when a cart is found.